### PR TITLE
correct string in p null print in macos

### DIFF
--- a/printf/42TESTERS-PRINTF-master/diff.txt
+++ b/printf/42TESTERS-PRINTF-master/diff.txt
@@ -3,3 +3,11 @@
 
 Binary files ft.txt and printf.txt differ
 
+----------Test 511 : ----------
+"%-2s, %.s, %-4s, %-2.4s, %-8.12s, %3s, %8s, %---2s, %.*s, %.0s, %.1s, %.2s, %.4s, %.8s" // 1st '*' = 12, 2nd '*' = 18
+
+1c1
+< (null), , (null),   , (null)  , (null),   (null), (null), (null), , , , , (null) --- Return : 80
+---
+> (null), , (null), (nul, (null)  , (null),   (null), (null), (null), , (, (n, (nul, (null) --- Return : 89
+

--- a/printf/ft_p_print.c
+++ b/printf/ft_p_print.c
@@ -6,7 +6,7 @@
 /*   By: gumartin <gumartin@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/23 19:52:14 by gumartin          #+#    #+#             */
-/*   Updated: 2020/10/30 13:14:57 by gumartin         ###   ########.fr       */
+/*   Updated: 2020/10/30 15:41:39 by mathferr         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ void	ft_p_print(t_conv *conv, va_list args)
 	}
 	if (conv->invalid == 1)
 	{
-	 	ft_putstr(conv, "(nil)");
+	 	ft_putstr(conv, "0x0");
 	}
 	ft_exec_flags(conv);
 }


### PR DESCRIPTION
Corrigindo o erro ao imprimir nil (ponteiro nulo) no Macos / Guacamole